### PR TITLE
Adjust gas limit to avoid insufficient fund error

### DIFF
--- a/packages/deposit/scripts/run.ts
+++ b/packages/deposit/scripts/run.ts
@@ -62,7 +62,7 @@ const main = async () => {
   ).wait()
   await (
     await inbox.connect(l1Wallet).depositNativeToken(amount, utils.parseEther('0.001'), {
-      gasLimit: 10000000,
+      gasLimit: 1000000,
     })
   ).wait()
   process.stdout.write('done\n')


### PR DESCRIPTION
When sender has inefficient ETH, less than gas * price + value, error. So adjust gasLimit. [Ref](https://ethereum.stackexchange.com/questions/9043/insufficient-funds-for-gas-price-value)
